### PR TITLE
Makes it possible to force fetch from network and overwrite cache content

### DIFF
--- a/DLImageLoader/DLILOperation/DLILOperation.h
+++ b/DLImageLoader/DLILOperation/DLILOperation.h
@@ -24,6 +24,7 @@ typedef void (^CancelBlock)();
 @interface DLILOperation : NSOperation <NSURLConnectionDelegate>
 
 @property (nonatomic, copy) NSString *url;
+@property (nonatomic) BOOL overwriteCache;
 
 - (id)initWithUrl:(NSString *)url;
 

--- a/DLImageLoader/DLILOperation/DLILOperation.m
+++ b/DLImageLoader/DLILOperation/DLILOperation.m
@@ -54,6 +54,7 @@
 - (void)configWithUrl:(NSString *)url
 {
     self.url = url;
+    self.overwriteCache = NO;
     requestData = [NSMutableData new];
 }
 
@@ -66,11 +67,13 @@
         return;
     }
     
-    UIImage *cachedImage = [[DLILCacheManager sharedInstance] imageByKey:self.url];
-    if (cachedImage) {
-        // successfull loading
-        if (completed) completed(nil, cachedImage);
-        return;
+    if (!self.overwriteCache) {
+        UIImage *cachedImage = [[DLILCacheManager sharedInstance] imageByKey:self.url];
+        if (cachedImage) {
+            // successfull loading
+            if (completed) completed(nil, cachedImage);
+            return;
+        }
     }
     
     self.completed = completed;

--- a/DLImageLoader/DLImageLoader.h
+++ b/DLImageLoader/DLImageLoader.h
@@ -21,6 +21,12 @@
 @interface DLImageLoader : NSObject
 
 /**
+ DLImageLoader overwriteCache
+ Default value NO
+ **/
+@property (nonatomic) BOOL overwriteCache;
+
+/**
  DLImageLoader logger
  Default value YES
  **/

--- a/DLImageLoader/DLImageLoader.m
+++ b/DLImageLoader/DLImageLoader.m
@@ -38,6 +38,7 @@
         instance.operationQueue = [[NSOperationQueue alloc] init];
         instance.cacheManager = [[DLILCacheManager alloc] init];
         instance.isDLILLogEnabled = NO;
+        instance.overwriteCache = NO;
     });
     return instance;
 }
@@ -56,6 +57,7 @@
 {
     if (self.isDLILLogEnabled) NSLog(@"DLImageLoader start data loading from %@", urlString);
     DLILOperation *operation = [[DLILOperation alloc] initWithUrl:urlString];
+    operation.overwriteCache = self.overwriteCache;
     [operation startLoadingWithCompletion:^(NSError *error, UIImage *image) {
         if (self.isDLILLogEnabled) NSLog(@"DLImageLoader data loading completed");
         if (completed) completed(error, image);


### PR DESCRIPTION
Had a need to force DLImageLoader to fetch new content from the network disregarding the cache.

Did not want to change a lot of method signatures, so I made a new property called overwriteCache.
